### PR TITLE
Fix CAT response processing (restores SWR and S-Meter functionality)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5878,6 +5878,7 @@ continueTuningAdjust(e) {
         this.updateDisplay(); // This will trigger band auto-selection
         document.getElementById('tuningKnob').setAttribute('aria-valuenow', this.frequency);
     }
+}
 
 
 // And replace the FB handler:
@@ -5936,8 +5937,10 @@ else if (response.startsWith('FB')) {
     // RIT status response
     const ritStatus = response.substring(2);
     if (ritStatus === '0' || ritStatus === '1') {
-        this.ritEnabled = (ritStatus === '1');
-        this.updateRITUI();
+        if (ritStatus === '1') {
+            this.ritEnabled = true;
+            this.updateRITUI();
+        }
         if (!this.isRITAdjusting) {
             this.logCAT(`RIT status: ${this.ritEnabled ? 'ON' : 'OFF'}`, 'rx');
         }
@@ -5952,7 +5955,6 @@ else if (response.startsWith('FB')) {
     }
 }
 
- }
 }
         
  /*      // Modify the initFrequencyKeyboard method to include this at the end:


### PR DESCRIPTION
Fix a regression in the `processResponse` method introduced by commit 2f0be1a:
Due to a misplaced closing bracket some received CAT commands were not evaluated, which amongst others breaks the SWR and S-Meter displays.

In addition to correcting the bracket placement, this pull request introduces a minor change to the RIT handling:
The RIT setting would be automatically disabled through the CAT commands immediately after enabling it (due to the QMX considering a RIT frequency of zero as RIT disabled). Therefore, now the RIT setting will not be disabled, when RIT is disabled directly at the QMX.